### PR TITLE
feat: track important metrics

### DIFF
--- a/components/snippet-view.tsx
+++ b/components/snippet-view.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Check, Copy, Terminal, Plus, Link as LinkIcon } from "lucide-react"
+import { track } from "@vercel/analytics/react"
 import type { Snippet } from "@/lib/snippets"
 
 interface SnippetViewProps {
@@ -18,16 +19,34 @@ export function SnippetView({ snippet, codePreview }: SnippetViewProps) {
   const previewUrl = `https://pastecn.vercel.app/p/${snippet.id}`
   const npxCommand = `npx shadcn@latest add ${registryUrl}.json`
 
+  // Track snippet view on mount
+  useEffect(() => {
+    track('snippet_viewed', {
+      snippet_id: snippet.id,
+      snippet_type: snippet.type,
+      language: snippet.meta.language,
+      content_length: snippet.content.length,
+    })
+  }, [snippet.id, snippet.type, snippet.meta.language, snippet.content.length])
+
   const handleCopyCommand = async () => {
     await navigator.clipboard.writeText(npxCommand)
     setCopiedCommand(true)
     setTimeout(() => setCopiedCommand(false), 3000)
+    track('command_copied', {
+      snippet_id: snippet.id,
+      snippet_type: snippet.type,
+    })
   }
 
   const handleCopyUrl = async () => {
     await navigator.clipboard.writeText(previewUrl)
     setCopiedUrl(true)
     setTimeout(() => setCopiedUrl(false), 3000)
+    track('preview_url_copied', {
+      snippet_id: snippet.id,
+      snippet_type: snippet.type,
+    })
   }
 
   return (


### PR DESCRIPTION
This pull request adds analytics tracking throughout the snippet registry and pastebin application to monitor user actions, errors, and system events. The tracking is implemented using the `@vercel/analytics` package in both server and client code. The most important changes are grouped below by theme.

**Error Tracking and Monitoring:**

* Added calls to `track` in `app/api/snippets/upload/route.ts` to log various upload errors, such as ID collisions, invalid IDs, size/content type/permission issues, and unknown errors, each with relevant metadata. [[1]](diffhunk://#diff-b29eeaab763d412f19b478c104414b9e151187bd125f8074462cdef6cc169c53R4) [[2]](diffhunk://#diff-b29eeaab763d412f19b478c104414b9e151187bd125f8074462cdef6cc169c53R50-R64) [[3]](diffhunk://#diff-b29eeaab763d412f19b478c104414b9e151187bd125f8074462cdef6cc169c53R76-R95) [[4]](diffhunk://#diff-b29eeaab763d412f19b478c104414b9e151187bd125f8074462cdef6cc169c53R108-R111)
* Added tracking of snippet creation errors (validation errors, ID collisions, upload failures) in `components/registry-pastebin.tsx`, including retry counts and error types. [[1]](diffhunk://#diff-a4aea2d50e2c96608e9d83ab26218c65e4de9cce79141c71c72b97012a5ae0a0R102-R105) [[2]](diffhunk://#diff-a4aea2d50e2c96608e9d83ab26218c65e4de9cce79141c71c72b97012a5ae0a0R175-R186)
* Tracked path validation errors in the registry pastebin component with details about the invalid path and registry type.

**User Interaction and Usage Tracking:**

* Logged successful snippet creation events, including metadata like registry type, filename usage, and code length, in `components/registry-pastebin.tsx`.
* Added tracking for registry type changes in the pastebin UI, recording the previous and new types.
* Tracked snippet view events, command copy actions, and preview URL copy actions in `components/snippet-view.tsx`, with snippet and usage metadata. [[1]](diffhunk://#diff-8c858ca9e5b4e075eada6cb6dec2eaa7cd91c0424e02038b5c8ffd8aa1750948L4-R6) [[2]](diffhunk://#diff-8c858ca9e5b4e075eada6cb6dec2eaa7cd91c0424e02038b5c8ffd8aa1750948R22-R49)

**Registry Access and Not-Found Tracking:**

* Tracked registry access and not-found events in `app/r/[id]/route.ts`, logging snippet IDs, user agents, referers, and normalized IDs for both successful and failed lookups. ([app/r/[id]/route.tsR4](diffhunk://#diff-a337618c2d5c598a2768e139a533742f3b49f5694e82e46ea8bf65a2ff2f5352R4), [app/r/[id]/route.tsR24-R27](diffhunk://#diff-a337618c2d5c598a2768e139a533742f3b49f5694e82e46ea8bf65a2ff2f5352R24-R27), [app/r/[id]/route.tsR37-R40](diffhunk://#diff-a337618c2d5c598a2768e139a533742f3b49f5694e82e46ea8bf65a2ff2f5352R37-R40), [app/r/[id]/route.tsR68-R74](diffhunk://#diff-a337618c2d5c598a2768e139a533742f3b49f5694e82e46ea8bf65a2ff2f5352R68-R74))