### PR TITLE
feat: add clear draft confirmation dialog

### DIFF
--- a/components/clear-draft-dialog.tsx
+++ b/components/clear-draft-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { nanoid } from "nanoid";
+import { track } from "@vercel/analytics/react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { LanguageType, RegistryType } from "./registry-pastebin";
+
+interface FileInput {
+  id: string;
+  code: string;
+  fileName: string;
+  language: LanguageType;
+  registryType: RegistryType;
+}
+
+interface DraftData {
+  files: FileInput[];
+  snippetName: string;
+}
+
+interface ClearDraftDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fileCount: number;
+  onClearDraft: () => void;
+  onResetDraftData: (data: DraftData) => void;
+}
+
+export function ClearDraftDialog({
+  open,
+  onOpenChange,
+  fileCount,
+  onClearDraft,
+  onResetDraftData,
+}: ClearDraftDialogProps) {
+  const handleClearDraft = () => {
+    onClearDraft();
+    onResetDraftData({
+      files: [
+        {
+          id: nanoid(),
+          code: "",
+          fileName: "",
+          language: "plaintext",
+          registryType: "file",
+        },
+      ],
+      snippetName: "",
+    });
+    track("draft_cleared", { file_count: fileCount });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="text-xl">Clear draft?</DialogTitle>
+          <DialogDescription className="pt-1">
+            This will reset all {fileCount > 1 ? `${fileCount} files` : "field"}
+            {fileCount > 1 ? "" : "s"} and remove your saved draft. This action
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="flex-1 sm:flex-initial"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleClearDraft}
+            className="flex-1 sm:flex-initial"
+          >
+            Clear Draft
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/registry-pastebin.tsx
+++ b/components/registry-pastebin.tsx
@@ -21,10 +21,11 @@ import {
 import { Kbd } from "./ui/kbd"
 import { useLocalStorageDraft } from "@/hooks/use-local-storage-draft"
 import { toast } from "@/hooks/use-toast"
+import { ClearDraftDialog } from "./clear-draft-dialog"
 
-type RegistryType = "file" | "component" | "hook" | "lib"
+export type RegistryType = "file" | "component" | "hook" | "lib"
 
-type LanguageType =
+export type LanguageType =
   | "typescript"
   | "javascript"
   | "tsx"
@@ -133,6 +134,7 @@ export function RegistryPastebin() {
   const [fileTypeMenuOpen, setFileTypeMenuOpen] = useState<string | false>(false)
   const [isUploading, setIsUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showClearDraftDialog, setShowClearDraftDialog] = useState(false)
 
   // Show toast when draft is restored
   useEffect(() => {
@@ -533,17 +535,7 @@ export function RegistryPastebin() {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => {
-                  // TODO: Add a confirmation dialog before shadcn kills me
-                  if (confirm("Clear draft? This will reset all fields.")) {
-                    clearDraft()
-                    setDraftData({
-                      files: [{ id: nanoid(), code: "", fileName: "", language: "plaintext", registryType: "file" }],
-                      snippetName: ""
-                    })
-                    track('draft_cleared', { file_count: files.length })
-                  }
-                }}
+                onClick={() => setShowClearDraftDialog(true)}
                 disabled={isUploading}
                 className={files.length === 1 ? "ml-auto" : ""}
               >
@@ -617,6 +609,15 @@ export function RegistryPastebin() {
           </nav>
         </div>
       </footer>
+
+      {/* Clear Draft Confirmation Dialog */}
+      <ClearDraftDialog
+        open={showClearDraftDialog}
+        onOpenChange={setShowClearDraftDialog}
+        fileCount={files.length}
+        onClearDraft={clearDraft}
+        onResetDraftData={setDraftData}
+      />
     </div>
   )
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the native browser `confirm()` used for the **Clear Draft** action with a proper confirmation dialog that matches the app’s UI system.

---

### Changes

- Removed usage of `window.confirm()`
- Added a UI-based confirmation dialog
- Preserved existing behavior:
  - Draft is only cleared after confirmation
  - Analytics tracking (`draft_cleared`) remains unchanged

---

### Screen Recording

https://github.com/user-attachments/assets/803f7c3b-8961-4a25-9cc8-b28ee07cd6ea

---

### Related Issue

Closes #24 
