### PR TITLE
feat: add 'Save as' label to filename input

### DIFF
--- a/components/registry-pastebin.tsx
+++ b/components/registry-pastebin.tsx
@@ -495,6 +495,9 @@ export function RegistryPastebin() {
                     {/* Filename Input */}
                     <InputGroupAddon align="block-end" className="border-t">
                       <div className="flex items-center gap-2 w-full">
+                        <InputGroupText className="hidden md:flex text-xs text-muted-foreground">
+                          Save as
+                        </InputGroupText>
                         <InputGroupText className="text-xs">
                           {fileTypeConfig.prefix}
                         </InputGroupText>


### PR DESCRIPTION
## Summary
- Adds a "Save as" label before the filename input prefix to make it clearer that users can edit the filename
- Label is hidden on mobile (`hidden md:flex`) to maintain clean UI on smaller screens
- Addresses user feedback about the filename edit functionality not being obvious

Closes #27

## Test plan
- [ ] Run `pnpm dev` and verify "Save as ~/filename.tsx" appears in desktop view
- [ ] Resize to mobile and verify only "~/filename.tsx" shows (no "Save as" label)
- [ ] Confirm input remains functional and editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)