### PR TITLE
feat: add animations to password protection buttons

### DIFF
--- a/components/registry-pastebin.tsx
+++ b/components/registry-pastebin.tsx
@@ -151,6 +151,7 @@ export function RegistryPastebin() {
   const [passwordProtected, setPasswordProtected] = useState(false)
   const [password, setPassword] = useState('')
   const [passwordCopied, setPasswordCopied] = useState(false)
+  const [passwordRegenerating, setPasswordRegenerating] = useState(false)
 
   // Expiration state
   const [expiration, setExpiration] = useState<ExpirationOption>('never')
@@ -606,14 +607,21 @@ export function RegistryPastebin() {
                   <Input
                     value={password}
                     readOnly
-                    className="font-mono text-sm"
+                    className={`font-mono text-sm transition-all duration-150 ease-out ${
+                      passwordRegenerating ? 'scale-[0.98] blur-[2px] opacity-70' : 'scale-100 blur-0 opacity-100'
+                    }`}
                   />
                   <Button
                     variant="outline"
                     size="icon"
+                    className="transition-transform duration-150 ease-out active:scale-[0.95]"
                     onClick={() => {
-                      setPassword(createSnippetPassword())
-                      setPasswordCopied(false)
+                      setPasswordRegenerating(true)
+                      setTimeout(() => {
+                        setPassword(createSnippetPassword())
+                        setPasswordCopied(false)
+                        setPasswordRegenerating(false)
+                      }, 150)
                       track('password_regenerated')
                     }}
                     disabled={isUploading}
@@ -624,6 +632,7 @@ export function RegistryPastebin() {
                   <Button
                     variant="outline"
                     size="icon"
+                    className="transition-transform duration-150 ease-out active:scale-[0.95]"
                     onClick={() => {
                       navigator.clipboard.writeText(password)
                       setPasswordCopied(true)


### PR DESCRIPTION
## Summary
Add micro-interactions to password protection buttons following [Emil Kowalski's animation tips](https://emilkowal.ski/ui/7-practical-animation-tips).

## Changes
- **Refresh & Copy buttons**: `active:scale-[0.95]` with `duration-150 ease-out` for tactile feedback
- **Password input**: blur + scale + opacity transition when regenerating password

## Animation principles applied
- **Tip #1**: Scale buttons on press (0.95)
- **Tip #4**: Use `ease-out` for responsive feel
- **Tip #6**: Keep fast (150ms)
- **Tip #7**: Blur to smooth state transitions

## Test plan
- [x] Enable password protection
- [x] Click Refresh - input blurs briefly, new password appears
- [x] Click Copy - button scales on press, shows checkmark

🤖 Generated with [Claude Code](https://claude.ai/code)