### PR TITLE
fix(vscode): skip duplicate versions on publish

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -84,8 +84,8 @@
     "typecheck": "tsc --noEmit",
     "package": "pnpm build && vsce package --no-dependencies",
     "package:pre": "pnpm build && vsce package --pre-release --no-dependencies",
-    "publish:vscode": "vsce publish --no-dependencies",
-    "publish:ovsx": "ovsx publish"
+    "publish:vscode": "vsce publish --no-dependencies --skip-duplicate",
+    "publish:ovsx": "ovsx publish --no-dependencies --skip-duplicate"
   },
   "devDependencies": {
     "@pastecn/typescript-config": "workspace:*",


### PR DESCRIPTION
## Summary
- Add `--skip-duplicate` flag to `vsce publish` and `ovsx publish` commands
- Prevents workflow failures when attempting to publish a version that already exists in the marketplace

## Test plan
- [ ] Merge this PR to trigger the release workflow
- [ ] Verify workflow completes successfully (should skip publishing since v0.0.2 already exists)
- [ ] Check logs for skip message

🤖 Generated with [Claude Code](https://claude.com/claude-code)