### PR TITLE
feat(web): add drag & drop file and folder upload (#46)

### DIFF
--- a/apps/web/app/blog/drag-drop-upload/page.tsx
+++ b/apps/web/app/blog/drag-drop-upload/page.tsx
@@ -1,0 +1,290 @@
+import Link from "next/link"
+import { Button } from "@pastecn/ui/components/button"
+import { ArrowRight, Upload, FolderOpen, FileCode, Zap, MousePointerClick } from "lucide-react"
+import type { Metadata } from "next"
+
+export const cache = false
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pastecn.com'
+
+export const metadata: Metadata = {
+  title: "Drag & Drop Upload — pastecn",
+  description: "Drag files or entire folders into pastecn to create multi-file snippets instantly. Language, type, and paths are auto-detected.",
+  keywords: ["drag and drop", "file upload", "multi-file snippets", "shadcn", "folder upload", "code sharing"],
+  openGraph: {
+    title: "Drag & Drop Upload — pastecn",
+    description: "Drag files or entire folders into pastecn to create multi-file snippets instantly. Language, type, and paths are auto-detected.",
+    url: `${siteUrl}/blog/drag-drop-upload`,
+    type: "article",
+    images: [
+      {
+        url: "/opengraph-image.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Drag & Drop Upload",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Drag & Drop Upload — pastecn",
+    description: "Drag files or entire folders into pastecn to create multi-file snippets instantly. Language, type, and paths are auto-detected.",
+    images: ["/opengraph-image.jpg"],
+  },
+  alternates: {
+    canonical: `${siteUrl}/blog/drag-drop-upload`,
+  },
+}
+
+export default function DragDropUploadPost() {
+  return (
+    <main className="min-h-screen">
+      <article className="container mx-auto px-4 py-16 md:py-24 max-w-2xl">
+        {/* Header */}
+        <header className="mb-16">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+          >
+            <ArrowRight className="w-4 h-4 rotate-180" />
+            Back to Blog
+          </Link>
+          <p className="text-sm text-muted-foreground mb-3 uppercase tracking-wide">Feature Announcement</p>
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight mb-4">
+            Drag & Drop Upload
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Drag files or entire folders from your computer to create multi-file snippets instantly. No more copy-pasting one file at a time.
+          </p>
+        </header>
+
+        {/* Content */}
+        <div className="prose prose-neutral max-w-none space-y-12">
+
+          {/* Introduction */}
+          <section className="space-y-4">
+            <p className="text-muted-foreground leading-relaxed text-base">
+              Creating multi-file snippets used to mean adding files one by one, typing filenames, pasting code,
+              and manually selecting the language and type for each. That workflow is gone.
+            </p>
+            <p className="text-muted-foreground leading-relaxed text-base">
+              Now you can drag files or folders directly from Finder, Explorer, or any file manager into the
+              pastecn editor. Everything is auto-detected: filename, language, registry type, and relative paths.
+            </p>
+          </section>
+
+          {/* How it works */}
+          <section className="space-y-6">
+            <h2 className="text-2xl font-semibold tracking-tight">How it works</h2>
+
+            <div className="space-y-8">
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary text-sm font-medium shrink-0 mt-0.5">
+                    1
+                  </div>
+                  <div className="flex-1 space-y-2">
+                    <h3 className="font-semibold text-foreground">Drag from your file manager</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Select files or folders in Finder, Explorer, or any file manager and drag them into the
+                      pastecn editor. A drop zone overlay appears to confirm.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary text-sm font-medium shrink-0 mt-0.5">
+                    2
+                  </div>
+                  <div className="flex-1 space-y-2">
+                    <h3 className="font-semibold text-foreground">Everything is auto-detected</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Language is inferred from file extensions. Registry type is inferred from the path:
+                      files in <code className="text-xs bg-muted px-1 py-0.5 rounded">hooks/</code> become hooks,
+                      files in <code className="text-xs bg-muted px-1 py-0.5 rounded">components/</code> become components,
+                      and so on.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary text-sm font-medium shrink-0 mt-0.5">
+                    3
+                  </div>
+                  <div className="flex-1 space-y-2">
+                    <h3 className="font-semibold text-foreground">Create the snippet</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Review the files, adjust anything if needed, and hit Create Snippet. You get a shareable
+                      registry URL that preserves your file structure.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Features */}
+          <section className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight">Features</h2>
+
+            <div className="grid gap-3">
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <div className="flex items-center gap-2 mb-1">
+                  <FolderOpen className="w-4 h-4 text-primary" />
+                  <span className="font-medium text-foreground">Folder support</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Drop entire folders and pastecn recursively reads all files inside, preserving the
+                  directory structure as relative paths.
+                </p>
+              </div>
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <div className="flex items-center gap-2 mb-1">
+                  <Zap className="w-4 h-4 text-primary" />
+                  <span className="font-medium text-foreground">Smart detection</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Language is inferred from extensions (.ts, .tsx, .css, .json, and more).
+                  Registry type is inferred from path conventions: hooks/, components/, lib/.
+                </p>
+              </div>
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <div className="flex items-center gap-2 mb-1">
+                  <MousePointerClick className="w-4 h-4 text-primary" />
+                  <span className="font-medium text-foreground">File picker fallback</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Prefer clicking? The Upload Files button opens your native file picker.
+                  Same auto-detection, different input method.
+                </p>
+              </div>
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <div className="flex items-center gap-2 mb-1">
+                  <FileCode className="w-4 h-4 text-primary" />
+                  <span className="font-medium text-foreground">Unsupported files handled</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Binary files, images, and unsupported extensions are automatically skipped with a
+                  notification. Only text files that pastecn supports are added.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Supported file types */}
+          <section className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight">Supported file types</h2>
+            <p className="text-muted-foreground leading-relaxed">
+              The following extensions are recognized and auto-detected:
+            </p>
+
+            <div className="bg-muted/30 border border-border rounded-lg overflow-hidden">
+              <div className="px-4 py-2 border-b border-border bg-muted/50">
+                <span className="text-xs font-mono text-muted-foreground">Extensions</span>
+              </div>
+              <div className="p-4">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {[
+                    { ext: ".ts", lang: "TypeScript" },
+                    { ext: ".tsx", lang: "TSX" },
+                    { ext: ".js", lang: "JavaScript" },
+                    { ext: ".jsx", lang: "JSX" },
+                    { ext: ".json", lang: "JSON" },
+                    { ext: ".md", lang: "Markdown" },
+                    { ext: ".css", lang: "CSS" },
+                    { ext: ".txt", lang: "Plain Text" },
+                  ].map(({ ext, lang }) => (
+                    <div key={ext} className="flex items-center gap-2">
+                      <code className="text-xs bg-background px-1.5 py-0.5 rounded border border-border font-mono">{ext}</code>
+                      <span className="text-xs text-muted-foreground">{lang}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              Files larger than 500 KB are skipped to keep snippets fast and lightweight.
+            </p>
+          </section>
+
+          {/* Path inference */}
+          <section className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight">Path-based type inference</h2>
+            <p className="text-muted-foreground leading-relaxed">
+              When you drop a folder, pastecn uses the file path to automatically set the registry type.
+              The matching prefix is stripped from the filename to avoid duplication.
+            </p>
+
+            <div className="bg-muted/30 border border-border rounded-lg overflow-hidden">
+              <div className="px-4 py-2 border-b border-border bg-muted/50">
+                <span className="text-xs font-mono text-muted-foreground">Examples</span>
+              </div>
+              <div className="p-4 space-y-3">
+                {[
+                  { path: "hooks/use-counter.ts", type: "Hook", filename: "use-counter.ts" },
+                  { path: "components/ui/button.tsx", type: "Component", filename: "ui/button.tsx" },
+                  { path: "lib/fetcher.ts", type: "Lib", filename: "fetcher.ts" },
+                  { path: "README.md", type: "File", filename: "README.md" },
+                ].map(({ path, type, filename }) => (
+                  <div key={path} className="flex items-center gap-3 text-sm">
+                    <code className="text-xs bg-background px-1.5 py-0.5 rounded border border-border font-mono flex-shrink-0">{path}</code>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <span className="text-muted-foreground">
+                      type: <span className="text-foreground font-medium">{type}</span>, file: <code className="text-xs bg-background px-1.5 py-0.5 rounded border border-border font-mono">{filename}</code>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          {/* Use Cases */}
+          <section className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight">Use cases</h2>
+            <div className="grid gap-3">
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <p className="text-sm text-foreground">
+                  <span className="font-medium">Share a component with its hooks.</span>
+                  <span className="text-muted-foreground"> Drop a folder with components and hooks together. Paths and types are preserved.</span>
+                </p>
+              </div>
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <p className="text-sm text-foreground">
+                  <span className="font-medium">Share a design system block.</span>
+                  <span className="text-muted-foreground"> Drop multiple related files and create a registry block that installs with a single command.</span>
+                </p>
+              </div>
+              <div className="bg-muted/30 rounded-lg p-4 border border-border">
+                <p className="text-sm text-foreground">
+                  <span className="font-medium">Quick prototyping.</span>
+                  <span className="text-muted-foreground"> Drag utility files from a project into pastecn to share a working setup with a teammate.</span>
+                </p>
+              </div>
+            </div>
+          </section>
+
+        </div>
+
+        {/* CTA */}
+        <div className="pt-8 mt-12 border-t border-border flex flex-col sm:flex-row gap-3">
+          <Button asChild size="lg" className="w-full sm:w-auto">
+            <Link href="/">
+              <Upload className="mr-2 h-4 w-4" />
+              Try It Now
+            </Link>
+          </Button>
+          <Button asChild size="lg" variant="outline" className="w-full sm:w-auto">
+            <a href="https://github.com/rbadillap/pastecn" target="_blank" rel="noopener noreferrer">
+              Star us on GitHub
+            </a>
+          </Button>
+        </div>
+      </article>
+    </main>
+  )
+}

--- a/apps/web/components/clear-draft-dialog.tsx
+++ b/apps/web/components/clear-draft-dialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@pastecn/ui/components/dialog";
-import { LanguageType, RegistryType } from "./registry-pastebin";
+import type { LanguageType, RegistryType } from "@/lib/registry";
 
 interface FileInput {
   id: string;

--- a/apps/web/components/registry-pastebin.tsx
+++ b/apps/web/components/registry-pastebin.tsx
@@ -354,13 +354,13 @@ export function RegistryPastebin() {
   return (
     <div className="relative flex flex-col min-h-screen" {...getRootProps()}>
       {/* Hidden file input for picker */}
-      <input {...getInputProps()} aria-label="Upload files" />
+      <input {...getInputProps()} />
 
       {/* Full-page drag overlay */}
       {isDragging && (
         <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary rounded-md pointer-events-none">
           <div className="text-center">
-            <Upload className="h-12 w-12 mx-auto mb-3 text-primary" aria-hidden="true" />
+            <Upload className="h-12 w-12 mx-auto mb-3 text-primary" />
             <p className="text-lg font-medium text-primary">Drop files or folders here</p>
             <p className="text-sm text-muted-foreground mt-1">.ts .tsx .js .jsx .json .md .css .txt</p>
           </div>
@@ -569,7 +569,7 @@ export function RegistryPastebin() {
                 onClick={openFilePicker}
                 disabled={isUploading}
               >
-                <Upload className="h-4 w-4 mr-1" aria-hidden="true" />
+                <Upload className="h-4 w-4 mr-1" />
                 Upload Files
               </Button>
               <Button

--- a/apps/web/components/registry-pastebin.tsx
+++ b/apps/web/components/registry-pastebin.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import { ChevronDown, Loader2, Code2, Plus, Lock, RefreshCw, Copy, Check, Clock } from "lucide-react"
+import { ChevronDown, Loader2, Code2, Plus, Lock, RefreshCw, Copy, Check, Clock, Upload } from "lucide-react"
 import { upload } from "@vercel/blob/client"
 import { nanoid } from "nanoid"
 import { track } from "@vercel/analytics/react"
@@ -32,45 +32,13 @@ import {
 import { Kbd } from "@pastecn/ui/components/kbd"
 import { useLocalStorageDraft } from "@/hooks/use-local-storage-draft"
 import { toast } from "@pastecn/ui/hooks/use-toast"
+import { useFileDrop } from "@/hooks/use-file-drop"
+import { languages, registryTypes, type LanguageType, type RegistryType } from "@/lib/registry"
 import { ClearDraftDialog } from "./clear-draft-dialog"
 
-export type RegistryType = "file" | "component" | "hook" | "lib"
+export type { RegistryType, LanguageType }
 
 export type ExpirationOption = '1h' | '24h' | '7d' | '30d' | 'never'
-
-export type LanguageType =
-  | "typescript"
-  | "javascript"
-  | "tsx"
-  | "jsx"
-  | "json"
-  | "markdown"
-  | "css"
-  | "plaintext"
-
-const languages: { value: LanguageType; label: string; extensions: string[] }[] = [
-  { value: "typescript", label: "TypeScript", extensions: [".ts"] },
-  { value: "tsx", label: "TSX", extensions: [".tsx"] },
-  { value: "javascript", label: "JavaScript", extensions: [".js", ".mjs", ".cjs"] },
-  { value: "jsx", label: "JSX", extensions: [".jsx"] },
-  { value: "json", label: "JSON", extensions: [".json"] },
-  { value: "markdown", label: "Markdown", extensions: [".md", ".mdx"] },
-  { value: "css", label: "CSS", extensions: [".css"] },
-  { value: "plaintext", label: "Plain Text", extensions: [".txt"] },
-]
-
-const registryTypes: {
-  value: RegistryType
-  label: string
-  prefix: string
-  placeholder: string
-  registryType: string
-}[] = [
-  { value: "file", label: "File", prefix: "~/", placeholder: "AGENTS.md", registryType: "registry:file" },
-  { value: "component", label: "Component", prefix: "components/", placeholder: "code-preview.tsx", registryType: "registry:component" },
-  { value: "hook", label: "Hook", prefix: "hooks/", placeholder: "use-copy-to-clipboard.ts", registryType: "registry:hook" },
-  { value: "lib", label: "Lib", prefix: "lib/", placeholder: "fetcher.ts", registryType: "registry:lib" },
-]
 
 // ID generation moved to server-side only for security
 
@@ -171,6 +139,22 @@ export function RegistryPastebin() {
       })
     }
   }, [hasDraft])
+
+  // Drag & drop file upload
+  const { isDragging, getRootProps, getInputProps, openFilePicker } = useFileDrop({
+    onFiles: (parsedFiles) => {
+      const newEntries: FileInput[] = parsedFiles.map(f => ({
+        id: nanoid(),
+        ...f,
+      }))
+      setFiles(prev => {
+        // Remove blank files (no code and no filename) before appending
+        const existing = prev.filter(f => f.code.trim() || f.fileName.trim())
+        return [...existing, ...newEntries]
+      })
+      track('files_dropped', { count: parsedFiles.length })
+    },
+  })
 
   // Auto-generate password when protection is enabled
   useEffect(() => {
@@ -368,7 +352,21 @@ export function RegistryPastebin() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="relative flex flex-col min-h-screen" {...getRootProps()}>
+      {/* Hidden file input for picker */}
+      <input {...getInputProps()} aria-label="Upload files" />
+
+      {/* Full-page drag overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary rounded-md pointer-events-none">
+          <div className="text-center">
+            <Upload className="h-12 w-12 mx-auto mb-3 text-primary" aria-hidden="true" />
+            <p className="text-lg font-medium text-primary">Drop files or folders here</p>
+            <p className="text-sm text-muted-foreground mt-1">.ts .tsx .js .jsx .json .md .css .txt</p>
+          </div>
+        </div>
+      )}
+
       {/* Main Content */}
       <div className="flex-1 container mx-auto px-4 pt-12 md:pt-20 pb-8 flex flex-col">
         <div className="flex-1 flex flex-col max-w-3xl mx-auto w-full">
@@ -501,7 +499,7 @@ export function RegistryPastebin() {
                     <InputGroupTextarea
                       value={file.code}
                       onChange={(e) => updateFile(file.id, { code: e.target.value })}
-                      placeholder="// Paste your code here..."
+                      placeholder="// Paste your code here…"
                       className="flex-1 font-mono text-sm min-h-[200px]"
                       spellCheck={false}
                       disabled={isUploading}
@@ -564,16 +562,27 @@ export function RegistryPastebin() {
                 Clear Draft
               </Button>
             )}
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={addFile}
-              disabled={isUploading}
-              className={`hover:text-muted-foreground ${files.length === 1 && !hasDraft ? "ml-auto" : ""}`}
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              Add File
-            </Button>
+            <div className={`flex items-center gap-2 ${files.length === 1 && !hasDraft ? "ml-auto" : ""}`}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={openFilePicker}
+                disabled={isUploading}
+              >
+                <Upload className="h-4 w-4 mr-1" aria-hidden="true" />
+                Upload Files
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={addFile}
+                disabled={isUploading}
+                className="hover:text-muted-foreground"
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Add File
+              </Button>
+            </div>
           </div>
 
           {/* Password Protection */}

--- a/apps/web/hooks/use-file-drop.ts
+++ b/apps/web/hooks/use-file-drop.ts
@@ -243,6 +243,7 @@ export function useFileDrop({ onFiles }: UseFileDropOptions) {
     onChange: onInputChange,
     className: "hidden",
     tabIndex: -1,
+    "aria-label": "Upload files",
   }), [onInputChange])
 
   const openFilePicker = useCallback(() => {

--- a/apps/web/hooks/use-file-drop.ts
+++ b/apps/web/hooks/use-file-drop.ts
@@ -1,0 +1,258 @@
+"use client"
+
+import { useState, useRef, useCallback, type ChangeEvent, type DragEvent } from "react"
+import {
+  registryTypes,
+  EXTENSION_TO_LANGUAGE,
+  SUPPORTED_EXTENSIONS,
+  type LanguageType,
+  type RegistryType,
+} from "@/lib/registry"
+import { toast } from "@pastecn/ui/hooks/use-toast"
+
+const MAX_FILE_SIZE = 500 * 1024 // 500KB per file
+
+export interface ParsedFile {
+  fileName: string
+  code: string
+  language: LanguageType
+  registryType: RegistryType
+}
+
+interface UseFileDropOptions {
+  onFiles: (files: ParsedFile[]) => void
+}
+
+interface ResolvedFile {
+  relativePath: string
+  file: File
+}
+
+function getExtension(fileName: string): string {
+  const lastDot = fileName.lastIndexOf(".")
+  return lastDot === -1 ? "" : fileName.slice(lastDot).toLowerCase()
+}
+
+function inferLanguage(fileName: string): LanguageType {
+  return EXTENSION_TO_LANGUAGE[getExtension(fileName)] ?? "plaintext"
+}
+
+function inferRegistryType(relativePath: string): RegistryType {
+  const lower = relativePath.toLowerCase()
+  const name = lower.split("/").pop() ?? lower
+  if (name.startsWith("use-") || lower.includes("hooks/")) return "hook"
+  if (lower.includes("components/")) return "component"
+  if (lower.includes("lib/") || lower.includes("utils/")) return "lib"
+  return "file"
+}
+
+// Strip the leading directory that matches the inferred registry type prefix
+// e.g. "hooks/use-file-drop.ts" with type "hook" (prefix "hooks/") → "use-file-drop.ts"
+//      "components/ui/button.tsx" with type "component" (prefix "components/") → "ui/button.tsx"
+function stripRegistryPrefix(relativePath: string, registryType: RegistryType): string {
+  const prefix = registryTypes.find((t) => t.value === registryType)?.prefix
+  if (!prefix || prefix === "~/") return relativePath
+  const lower = relativePath.toLowerCase()
+  if (lower.startsWith(prefix.toLowerCase())) {
+    return relativePath.slice(prefix.length)
+  }
+  return relativePath
+}
+
+function isBinary(content: string): boolean {
+  return content.slice(0, 512).includes("\x00")
+}
+
+// Recursively read a FileSystemEntry and collect all files with relative paths
+function readEntry(entry: FileSystemEntry, basePath: string): Promise<ResolvedFile[]> {
+  return new Promise((resolve) => {
+    if (entry.isFile) {
+      (entry as FileSystemFileEntry).file(
+        (file) => resolve([{ relativePath: basePath + file.name, file }]),
+        () => resolve([]) // skip on error
+      )
+    } else if (entry.isDirectory) {
+      const reader = (entry as FileSystemDirectoryEntry).createReader()
+      const allEntries: FileSystemEntry[] = []
+
+      // readEntries returns batches of max ~100 entries, must call until empty
+      const readBatch = () => {
+        reader.readEntries(
+          (entries) => {
+            if (entries.length === 0) {
+              Promise.all(
+                allEntries.map((e) => readEntry(e, basePath + entry.name + "/"))
+              ).then((results) => resolve(results.flat()))
+            } else {
+              allEntries.push(...entries)
+              readBatch()
+            }
+          },
+          () => resolve([]) // skip on error
+        )
+      }
+      readBatch()
+    } else {
+      resolve([])
+    }
+  })
+}
+
+// Extract files from a drop event, handling both files and directories
+async function resolveDropItems(dataTransfer: DataTransfer): Promise<ResolvedFile[]> {
+  const items = dataTransfer.items
+  const entries: FileSystemEntry[] = []
+
+  // Try to get entries (supports directories)
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (!item) continue
+    const entry = item.webkitGetAsEntry?.()
+    if (entry) entries.push(entry)
+  }
+
+  if (entries.length > 0) {
+    const results = await Promise.all(entries.map((e) => readEntry(e, "")))
+    return results.flat()
+  }
+
+  // Fallback: plain files (no directory support)
+  return Array.from(dataTransfer.files).map((file) => ({
+    relativePath: file.name,
+    file,
+  }))
+}
+
+export function useFileDrop({ onFiles }: UseFileDropOptions) {
+  const [isDragging, setIsDragging] = useState(false)
+  const dragCounterRef = useRef(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const processResolvedFiles = useCallback(async (resolvedFiles: ResolvedFile[]) => {
+    const parsed: ParsedFile[] = []
+    const skipped: { name: string; reason: string }[] = []
+
+    const promises = resolvedFiles.map(async ({ relativePath, file }) => {
+      const ext = getExtension(file.name)
+
+      if (!SUPPORTED_EXTENSIONS.includes(ext)) {
+        skipped.push({ name: relativePath, reason: "unsupported type" })
+        return
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        skipped.push({ name: relativePath, reason: "exceeds 500KB" })
+        return
+      }
+
+      try {
+        const content = await file.text()
+
+        if (isBinary(content)) {
+          skipped.push({ name: relativePath, reason: "binary file" })
+          return
+        }
+
+        const type = inferRegistryType(relativePath)
+
+        parsed.push({
+          fileName: stripRegistryPrefix(relativePath, type),
+          code: content,
+          language: inferLanguage(file.name),
+          registryType: type,
+        })
+      } catch {
+        skipped.push({ name: relativePath, reason: "read error" })
+      }
+    })
+
+    await Promise.all(promises)
+
+    if (parsed.length > 0) {
+      onFiles(parsed)
+    }
+
+    if (skipped.length > 0) {
+      toast({
+        title: `${skipped.length} file${skipped.length > 1 ? "s" : ""} skipped`,
+        description: skipped.map((s) => `${s.name}: ${s.reason}`).join(", "),
+        duration: 5000,
+      })
+    }
+  }, [onFiles])
+
+  // Process files from the <input> file picker (no directory support here)
+  const processFileList = useCallback(async (fileList: FileList) => {
+    const resolved: ResolvedFile[] = Array.from(fileList).map((file) => ({
+      relativePath: file.name,
+      file,
+    }))
+    await processResolvedFiles(resolved)
+  }, [processResolvedFiles])
+
+  const onDragEnter = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    dragCounterRef.current++
+    if (dragCounterRef.current === 1) {
+      setIsDragging(true)
+    }
+  }, [])
+
+  const onDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    dragCounterRef.current--
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false)
+    }
+  }, [])
+
+  const onDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault()
+  }, [])
+
+  const onDrop = useCallback(async (e: DragEvent) => {
+    e.preventDefault()
+    dragCounterRef.current = 0
+    setIsDragging(false)
+
+    const resolved = await resolveDropItems(e.dataTransfer)
+    if (resolved.length > 0) {
+      await processResolvedFiles(resolved)
+    }
+  }, [processResolvedFiles])
+
+  const onInputChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      processFileList(e.target.files)
+      e.target.value = "" // reset so the same files can be re-selected
+    }
+  }, [processFileList])
+
+  const getRootProps = useCallback(() => ({
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop,
+  }), [onDragEnter, onDragLeave, onDragOver, onDrop])
+
+  const getInputProps = useCallback(() => ({
+    ref: inputRef,
+    type: "file" as const,
+    multiple: true,
+    accept: SUPPORTED_EXTENSIONS.join(","),
+    onChange: onInputChange,
+    className: "hidden",
+    tabIndex: -1,
+  }), [onInputChange])
+
+  const openFilePicker = useCallback(() => {
+    inputRef.current?.click()
+  }, [])
+
+  return {
+    isDragging,
+    getRootProps,
+    getInputProps,
+    openFilePicker,
+  }
+}

--- a/apps/web/lib/blog-posts.ts
+++ b/apps/web/lib/blog-posts.ts
@@ -10,6 +10,14 @@ export type BlogPost = {
 
 export const blogPosts: BlogPost[] = [
   {
+    slug: "drag-drop-upload",
+    title: "Drag & Drop Upload",
+    description: "Drag files or entire folders into pastecn to create multi-file snippets instantly. Language, type, and paths are auto-detected.",
+    date: "2026-03-30",
+    category: "Feature Announcement",
+    image: "/opengraph-image.jpg"
+  },
+  {
     slug: "vscode-extension",
     title: "VS Code Extension",
     description: "Share code snippets directly from VS Code. Select code, press a shortcut, and get a shareable URL.",

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -1,0 +1,42 @@
+export type RegistryType = "file" | "component" | "hook" | "lib"
+
+export type LanguageType =
+  | "typescript"
+  | "javascript"
+  | "tsx"
+  | "jsx"
+  | "json"
+  | "markdown"
+  | "css"
+  | "plaintext"
+
+export const languages: { value: LanguageType; label: string; extensions: string[] }[] = [
+  { value: "typescript", label: "TypeScript", extensions: [".ts"] },
+  { value: "tsx", label: "TSX", extensions: [".tsx"] },
+  { value: "javascript", label: "JavaScript", extensions: [".js", ".mjs", ".cjs"] },
+  { value: "jsx", label: "JSX", extensions: [".jsx"] },
+  { value: "json", label: "JSON", extensions: [".json"] },
+  { value: "markdown", label: "Markdown", extensions: [".md", ".mdx"] },
+  { value: "css", label: "CSS", extensions: [".css"] },
+  { value: "plaintext", label: "Plain Text", extensions: [".txt"] },
+]
+
+export const registryTypes: {
+  value: RegistryType
+  label: string
+  prefix: string
+  placeholder: string
+  registryType: string
+}[] = [
+  { value: "file", label: "File", prefix: "~/", placeholder: "AGENTS.md", registryType: "registry:file" },
+  { value: "component", label: "Component", prefix: "components/", placeholder: "code-preview.tsx", registryType: "registry:component" },
+  { value: "hook", label: "Hook", prefix: "hooks/", placeholder: "use-copy-to-clipboard.ts", registryType: "registry:hook" },
+  { value: "lib", label: "Lib", prefix: "lib/", placeholder: "fetcher.ts", registryType: "registry:lib" },
+]
+
+// Derived lookups
+export const EXTENSION_TO_LANGUAGE: Record<string, LanguageType> = Object.fromEntries(
+  languages.flatMap(({ value, extensions }) => extensions.map((ext) => [ext, value]))
+) as Record<string, LanguageType>
+
+export const SUPPORTED_EXTENSIONS = Object.keys(EXTENSION_TO_LANGUAGE)


### PR DESCRIPTION
Add drag & drop and file picker support to the snippet editor, allowing users to drop files or entire folders from their OS to auto-populate the editor with content, filename, language, and registry type inferred automatically.

- New `use-file-drop` hook with recursive directory traversal via `webkitGetAsEntry()`, binary detection, size limits, and skip toasts
- Centralize types and constants into `lib/registry.ts` (single source of truth for languages, registry types, extension mappings)
- Auto-remove blank files when new files are dropped
- Strip registry prefix from paths to avoid duplication
- Accessibility: aria-label on file input, aria-hidden on decorative icons
- Update overlay copy to reflect folder support

Closes #46